### PR TITLE
potential better performance with get_sample_count

### DIFF
--- a/viper/core/database.py
+++ b/viper/core/database.py
@@ -334,4 +334,4 @@ class Database:
         
     def get_sample_count(self):
         session = self.Session()
-        return session.query(Malware).count()
+        return session.query(Malware.id).count()


### PR DESCRIPTION
I found viper startup still not fast enough and tried a bit with the count query and looks like that is increasing performance a lot (also refered in: https://stackoverflow.com/a/12942318)

(I am currently testing with an viper database with around 400 k samples)

maybe someone can verify that.

Thanks