### PR TITLE
add download from VirusTotal and Comment on reports commands

### DIFF
--- a/modules/virustotal.py
+++ b/modules/virustotal.py
@@ -2,6 +2,8 @@
 # See the file 'LICENSE' for copying permission.
 
 
+import tempfile
+
 try:
     import requests
     HAVE_REQUESTS = True
@@ -14,6 +16,7 @@ from viper.core.session import __sessions__
 
 VIRUSTOTAL_URL = 'https://www.virustotal.com/vtapi/v2/file/report'
 VIRUSTOTAL_URL_SUBMIT = 'https://www.virustotal.com/vtapi/v2/file/scan'
+VIRUSTOTAL_URL_DOWNLOAD = 'https://www.virustotal.com/vtapi/v2/file/download'
 KEY = 'a0283a2c3d55728300d064874239b5346fb991317e8449fe43c902879d758088'
 
 
@@ -24,7 +27,10 @@ class VirusTotal(Module):
 
     def __init__(self):
         super(VirusTotal, self).__init__()
-        self.parser.add_argument('-s', '--submit', action='store_true', help='Submit file to VirusTotal (by default it only looks up the hash)')
+        self.parser.add_argument('-s','--submit', action='store_true')
+        self.parser.add_argument('-d','--download', action='store', dest='hash')
+
+
 
     def run(self):
 
@@ -32,7 +38,31 @@ class VirusTotal(Module):
         if self.args is None:
             return
 
+
+        arg_download = False
         arg_submit = False
+
+        if self.args.hash:
+            try:
+                params = {'apikey': KEY,'hash':self.args.hash}
+                response = requests.get(VIRUSTOTAL_URL_DOWNLOAD, params=params)
+
+                if response.status_code == 403:
+                    self.log('error','This command requires virustotal private API key')
+                    self.log('error','Please check that your key have the right permissions')
+                    return
+                if response.status_code == 200:
+                    response = response.content
+                    tmp = tempfile.NamedTemporaryFile(delete=False)
+                    tmp.write(response)
+                    tmp.close()
+                    return __sessions__.new(tmp.name)
+
+            except Exception as e:
+                    self.log('error', "Failed Download: {0}".format(e))
+
+
+
         if self.args.submit:
             arg_submit = True
 


### PR DESCRIPTION
Add the ability to download files from VirusTotal via its private API. 
This is done even before a session is started and returns a new session.

$ virustotal  -d / --download hash 

Also add the ability to comment on open session if file report found.
$ virustotal -c / --comment what ever you want to comment 

to do:
Add the same ability to web.py 
add open --virustotal to call this command. 

I'm not sure how this will go together with the current shared key since downloads are blocked and commenting might cause "spam" issue. 
Maybe VirusTotal can block that specific key from commenting? 
It might not be perfect but I guess people can comment and think if this is an appropriate addition. 




