### PR TITLE
add virustotal option to web interface and open command

### DIFF
--- a/data/web/index.tpl
+++ b/data/web/index.tpl
@@ -91,6 +91,30 @@ $(document).ready( function() {
     </div>
 </div>
 
+<!-- Download from Virustotal -->
+<div class="panel panel-default">
+    <div class="panel-heading">
+        <h3 class="panel-title">VirusTotal Download</h3>
+    </div>
+    <div class="panel-body">
+        <form class="form-inline" role="form" action="/VTDownload" enctype="multipart/form-data" method="post" name="submit">
+            <div class="form-group">
+                <label class="sr-only" for="HASH">hash</label>
+                <input type="search" class="form-control" name="hash" id="hash" placeholder="HASH">
+            </div>
+
+            <div class="form-group">
+                <label for="tag_list">Tags</label>
+                <input type="text" class="form-control" name="tag_list" id="tag_list" placeholder="List of Tags">
+            </div>
+
+            <button type="submit" class="btn btn-default">Run</button>
+        </form>
+    </div>
+</div>
+
+
+
 <!-- Search -->
 <div class="panel panel-default">
     <div class="panel-heading">

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,3 +16,4 @@ dnspython
 git+https://github.com/smarnach/pyexiftool.git#egg=pyexiftool
 pyasn1
 M2Crypto
+

--- a/viper/core/ui/commands.py
+++ b/viper/core/ui/commands.py
@@ -88,6 +88,7 @@ class Commands(object):
         group = parser.add_mutually_exclusive_group()
         group.add_argument('-f', '--file', action="store_true", help="target is a file")
         group.add_argument('-u', '--url', action="store_true", help="target is a URL")
+        group.add_argument('-v', '--virustotal', action="store_true", help="target is an hash")
         group.add_argument('-l', '--last', action="store_true", help="target is the entry number from the last find command's results")
         parser.add_argument('-t', '--tor', action="store_true", help="Download the file through Tor")
         parser.add_argument("value", metavar='Path, URL, hash or ID', nargs='*', help="Target to open. Hash can be md5 or sha256. ID has to be from the last search.")
@@ -122,6 +123,13 @@ class Commands(object):
                 tmp.close()
 
                 __sessions__.new(tmp.name)
+
+        elif args.virustotal:
+            args = ('-d',target)
+            module = __modules__['virustotal']['obj']()
+            module.set_commandline(args)
+            module.run()
+
         # Try to open the specified file from the list of results from
         # the last find command.
         elif args.last:


### PR DESCRIPTION
This commit allows download from virustotal via the web interface:
Since I wanted to keep virustotal module to open a new session when triggered from the console but still call it from the web interface I had to introduce new argument (-w, --web):
This enables a little "check" to decide which type to return, (new session or raw data): 
self.parser.add_argument('-w', '--web', action='store_true', help='distinguish between calls from web or console')

if self.args.web:
    return response
return __sessions__.new(tmp.name)


Also add an option to start a new session via open command:
$open -vt / --virustotal hash (returns a session as well) 

Please let me know what you think

