### PR TITLE
[Database] fix sorting error mentioned in https://github.com/botherder/viper/issues/206

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -9,6 +9,7 @@ Viper 1.2 (TBD)
 - Fixed multiuple bugs in email module
 - Fixed bug in strings module
 - Added clustering in virustotal module
+- Fixed "latest"-database method to return latest file based on id rather then created_at
 
 Viper 1.1 (2014-10-22)
 ======================

--- a/viper/core/database.py
+++ b/viper/core/database.py
@@ -307,7 +307,7 @@ class Database:
             else:
                 value = 5
             
-            rows = session.query(Malware).order_by(Malware.created_at.desc()).limit(value).offset(offset)
+            rows = session.query(Malware).order_by(Malware.id.desc()).limit(value).offset(offset)
         elif key == 'md5':
             rows = session.query(Malware).filter(Malware.md5 == value).all()
         elif key == 'sha256':


### PR DESCRIPTION
This fix is to adress https://github.com/botherder/viper/issues/206, if you store multiple files at a time, the order by created_ad is returning wrong ordered files, by ordering id the issue is fixed.

---
    [+] Stored file "VirusShare_0c239f923c39f6fe9ef278dad14c0438" to /Volumes//viper/binaries/1/6/2/8/16286759b918a1b2cf0d8fc89dff97533a5e1f21ff82f581b6cec48c0a9de7b0
    [+] Stored file "VirusShare_0c558b1505c9e91d71d97ed64ab4704b" to /Volumes//viper/binaries/3/9/8/4/39843f7b2100c6db60018363f9c2b9d9240bf801d6b5f2ed5eec6bc868cf1775
    [+] Stored file "VirusShare_0c59f8bbb8328bc8f3707bb43ab3e34f" to /Volumes//viper/binaries/5/d/6/6/5d66d372942af0b88b7207bdd468084f90d76208f41a26b76f69c060ccb65220
    [+] Stored file "VirusShare_0c5c519da56553923345e87f9d47b7a2" to /Volumes//viper/binaries/3/c/9/3/3c9320800ca39857d74124bfedfc2e66002a7c7924bfdab6d68cf594d8e10469
    [+] Stored file "VirusShare_0c7ccf14de37e4387ae3def2eb34b3c4" to /Volumes//viper/binaries/c/0/f/3/c0f3aeaee9f81f276fa30825f97d122965be8eed59f43269829d3ba7f03b2eef
    [+] Stored file "VirusShare_0c870bb7c15051af0c04027042fa3c58" to /Volumes//viper/binaries/c/7/9/7/c79722be98b4c2a3693bbce226d0574923de9f03ab951abd3ef92e8984a4ba3c
    [+] Stored file "VirusShare_0c90fc1819fb426416c08f9a2c5e4e7f" to /Volumes//viper/binaries/6/f/5/a/6f5a1e706ec79afcfc92e03ad10b1ac967689475c55a9c5e2c47bd9d4204d458
    [+] Stored file "VirusShare_0ca08016dd907cb62c94e721a341f85c" to /Volumes//viper/binaries/4/6/6/7/4667918e50608066977379f126e8b5ef53ef7fe46eaa8a1d2658c70823903a60
    [+] Stored file "VirusShare_0caa72151b6613ed7fa52321d03a18d8" to /Volumes//viper/binaries/8/7/c/b/87cb51fd668b06757aa1716a09f21542507ae20efa1510231b43be5baa84cb37
    [+] Stored file "VirusShare_0cb5fe65b5f6a666d67185c20f34eeb7" to /Volumes//viper/binaries/e/2/b/7/e2b7d5627689b17d512a00b0a7eaf2dd9a5639624cdbb41e07d09a57999f2b4c
    [+] Stored file "VirusShare_0cbe57310b127d5ce35f1b2df3070ec0" to /Volumes//viper/binaries/2/9/6/6/2966b769fb1c4e81ecfc3a52c45a1ed21fb922527a8cbf818c99dd11a2612277
---

So the file: 0cbe57310b127d5ce35f1b2df3070ec0 is the latest

output before:

    viper > find latest
    +---+---------------------------------------------+------+----------------------------------+------+----------------------------+
    | # | Name                                        | Mime | MD5                              | Tags | Created At                 |
    +---+---------------------------------------------+------+----------------------------------+------+----------------------------+
    | 1 | VirusShare_00011bf7484b730cf304265d57db8d77 |      | 00011bf7484b730cf304265d57db8d77 |      | 2015-01-29 17:27:20.035529 |
    | 2 | VirusShare_000c15cfd50adc583f86031deb0d33e4 |      | 000c15cfd50adc583f86031deb0d33e4 |      | 2015-01-29 17:27:20.035529 |
    | 3 | VirusShare_000c4f7bd4b256fad1c16d4b3acf8c8a |      | 000c4f7bd4b256fad1c16d4b3acf8c8a |      | 2015-01-29 17:27:20.035529 |
    | 4 | VirusShare_001367ff05e056c81c2c7f854487c7e0 |      | 001367ff05e056c81c2c7f854487c7e0 |      | 2015-01-29 17:27:20.035529 |
    | 5 | VirusShare_00235725b9d3f7536bc2622690cd1977 |      | 00235725b9d3f7536bc2622690cd1977 |      | 2015-01-29 17:27:20.035529 |
    +---+---------------------------------------------+------+----------------------------------+------+----------------------------+


output after:

    viper > find latest
    +---+---------------------------------------------+------+----------------------------------+------+----------------------------+
    | # | Name                                        | Mime | MD5                              | Tags | Created At                 |
    +---+---------------------------------------------+------+----------------------------------+------+----------------------------+
    | 1 | VirusShare_0cbe57310b127d5ce35f1b2df3070ec0 |      | 0cbe57310b127d5ce35f1b2df3070ec0 |      | 2015-01-29 17:27:20.035529 |
    |    2 | VirusShare_0cb5fe65b5f6a666d67185c20f34eeb7 |      | 0cb5fe65b5f6a666d67185c20f34eeb7 |      | 2015-01-29 17:27:20.035529 |
    | 3 | VirusShare_0caa72151b6613ed7fa52321d03a18d8 |      | 0caa72151b6613ed7fa52321d03a18d8 |      | 2015-01-29 17:27:20.035529 |
    | 4 | VirusShare_0ca08016dd907cb62c94e721a341f85c |      | 0ca08016dd907cb62c94e721a341f85c |      | 2015-01-29 17:27:20.035529 |
    | 5 | VirusShare_0c90fc1819fb426416c08f9a2c5e4e7f |      | 0c90fc1819fb426416c08f9a2c5e4e7f |      | 2015-01-29 17:27:20.035529 |
    +---+---------------------------------------------+------+----------------------------------+------+----------------------------+
