### PR TITLE
exception handling for non OSX binaries

### DIFF
--- a/modules/macho.py
+++ b/modules/macho.py
@@ -81,7 +81,11 @@ class Macho(Module):
                 segment.display(before="\t")
         
         
-        m = MachO(__sessions__.current.file.path)
+        try:
+            m = MachO(__sessions__.current.file.path)
+        except Exception as e:
+            self.log('error', "No Mach0 file, {0}".format(e))
+            return
                 
         if self.args is None:
             return


### PR DESCRIPTION
adressing https://github.com/botherder/viper/issues/242

I have tested it with the samples from https://github.com/thetlk/Mach-O/tree/master/sample --> worked as expected
and tested it with samples I had in my repository 

positiv:
```
viper bin-ls-i386 > macho -hd
[*] Headers: 
 - magic : 0xfeedface - 32 bits
 - cputype : 0x7 - i386
 - cpusubtype : 0x3
 - filetype : 0x2 - executable file
 - ncmds : 16
 - sizeofcmds : 1528 bytes
 - flags : 0x1200085 - NOUNDEFS, DYLDLINK, TWOLEVEL, PIE, NO_HEAP_EXECUTION
viper bin-ls-i386 > info
+--------+----------------------------------------------------------------------------------------------------------------------------------+
| Key    | Value                                                                                                                            |
+--------+----------------------------------------------------------------------------------------------------------------------------------+
| Name   | bin-ls-i386                                                                                                                      |
| Tags   |                                                                                                                                  |
| Path   | bin-ls-i386                                                                                                                      |
| Size   | 35696                                                                                                                            |
| Type   | Mach-O executable i386                                                                                                           |
| Mime   |                                                                                                                                  |
| MD5    | df2580eaf51e15e23de3db979992af1e                                                                                                 |
| SHA1   | d0ee95ac7ef1127bc9a4f72cbaed3d975f779686                                                                                         |
| SHA256 | f6192f91dbf2bb98d846a0e409bcd2895cb8e04016f0476c3c4d22af3713f5e0                                                                 |
| SHA512 | 842f2e9bd7e893d4784dabf8485b7277d80f419fd433c03489598554af5946ce258ecb7fbbbb20390b01af7c4cf7a2b964e7f6bdb812e65ee96225308048aa2f |
| SSdeep |                                                                                                                                  |
| CRC32  | 0B87884F                                                                                                                         |
+--------+----------------------------------------------------------------------------------------------------------------------------------+
```

negativ:
```
viper 58d5ffe4a3bce374d3080f89a84857c06dfd89c4247afc352811f62307152dea > macho -a
[!] No Mach0 file
viper 58d5ffe4a3bce374d3080f89a84857c06dfd89c4247afc352811f62307152dea > info
+--------+----------------------------------------------------------------------------------------------------------------------------------+
| Key    | Value                                                                                                                            |
+--------+----------------------------------------------------------------------------------------------------------------------------------+
| Name   | 58d5ffe4a3bce374d3080f89a84857c06dfd89c4247afc352811f62307152dea                                                                 |
| Tags   |                                                                                                                                  |
| Path   | 58d5ffe4a3bce374d3080f89a84857c06dfd89c4247afc352811f62307152dea                                                                 |
| Size   | 252797                                                                                                                           |
| Type   | PE32 executable for MS Windows (GUI) Intel 80386 32-bit                                                                          |
| Mime   |                                                                                                                                  |
| MD5    | 65c88cca3f5afb2fa81485f7971cb4f4                                                                                                 |
| SHA1   | 9fd76a800eca9d56cd76184ec6df05762b874bc0                                                                                         |
| SHA256 | 58d5ffe4a3bce374d3080f89a84857c06dfd89c4247afc352811f62307152dea                                                                 |
| SHA512 | 3b397d8aad28b03524b05932efaf04260c79741441ffa440d90c214c84bbd62719f3fd01b8c4b15535d33d8a09c21af89dcc74423bbe19dcf2435a27db1d439c |
| SSdeep |                                                                                                                                  |
| CRC32  | 22E5F52A                                                                                                                         |
+--------+----------------------------------------------------------------------------------------------------------------------------------+
viper 58d5ffe4a3bce374d3080f89a84857c06dfd89c4247afc352811f62307152dea >
```