### PR TITLE
Display the task id of the file sent to cuckoo

### DIFF
--- a/modules/cuckoo.py
+++ b/modules/cuckoo.py
@@ -44,5 +44,32 @@ class Cuckoo(Module):
         try:
             response = requests.post(url, files=files)
         except requests.ConnectionError:
-            self.log('error', "Unable to connect to Cuckoo API at {0}:{1}".format(host, port))
+            self.log('error', "Unable to connect to Cuckoo API at '{0}'.".format(url))
             return
+        except Exception as e:
+            self.log('error', "Failed performing request at '{0}': {1}".format(url, e))
+            return
+
+        try:
+            cuckoo = response.json()
+            # since python 2.7 the above line causes the Error dict object not callable
+        except Exception as e:
+            # workaround in case of python 2.7
+            if str(e) == "'dict' object is not callable":
+                try:
+                    cuckoo = response.json
+                except Exception as e:
+                    self.log('error', "Failed parsing the response: {0}".format(e))
+                    self.log('error', "Data:\n{}".format(response.content))
+                    return
+            else:
+                self.log('error', "Failed parsing the response: {0}".format(e))
+                self.log('error', "Data:\n{}".format(response.content))
+                return
+	try:
+		task_id = cuckoo["task_id"]
+		self.log('info', "Task ID: {0}".format(task_id))
+		return
+	except Excetpion as e:
+		self.log('error', "Failed to parse the task id from the returned JSON ('{0}'): {1}".format(cuckoo, e))
+		return


### PR DESCRIPTION
When using viper with the `cuckoo` command I missed a feedback when you submitted your file to cuckoo.

I added a very simple logic to display the task number which cuckoo returns.

Note that I've never before used python and copied most stuff from the `virustotal.py` file. So feel free to adjust it as you want or to tell me what I did wrong.