### PR TITLE
Typo in error message when missing module

### DIFF
--- a/modules/elf.py
+++ b/modules/elf.py
@@ -134,7 +134,7 @@ class ELF(Module):
             return
 
         if not HAVE_ELFTOOLS:
-            self.log('error', "Missing dependency, install pyelftools (`pip install pyelftools")
+            self.log('error', "Missing dependency, install pyelftools (`pip install pyelftools`)")
             return
 
         if self.args.sections:


### PR DESCRIPTION
fixed a typo in error message if pyelftools is not installed